### PR TITLE
shell starter for windows machines

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,13 @@
+@echo off
+set JAR=lib\crowd-ldap-server-1.0.1-SNAPSHOT.jar
+set CLASSPATH=etc
+rem Apache DS Settings
+set FIXADS="-Duser.language=en -Duser.country=US"
+
+rem SSL Debugging
+rem set DEBUG_SSL="-Djavax.net.debug=ssl"
+set DEBUG_SSL=
+
+rem Run Server
+java.exe %FIXADS% %DEBUG_SSL% -Djava.awt.headless=true -cp %classpath% -jar %JAR% %*
+


### PR DESCRIPTION
Small addition for users wanting to run this in a windows environment.
Some assumptions are made:

java.exe is available in your system path
you are running this cmd from where you extracted the ldap server files.
Additional modifications will be necessary if you want to run this as a windows service.
